### PR TITLE
Bugfix in ColorHSL.fromColor()

### DIFF
--- a/phoenix/Color.hx
+++ b/phoenix/Color.hx
@@ -437,8 +437,8 @@ class ColorHSL extends Color {
         }
 
             h = _h;
-            s = _h;
-            l = _h;
+            s = _s;
+            l = _l;
             a = _color.a;
 
         return this;


### PR DESCRIPTION
Hue temp variable was assigned to saturation and lightness, returning incorrect colors. Now temp _s assigned to s and temp _l assigned to l.
