### PR TITLE
Use Path.normalize when resolving texture path

### DIFF
--- a/luxe/importers/tiled/TiledMap.hx
+++ b/luxe/importers/tiled/TiledMap.hx
@@ -67,7 +67,7 @@ class TiledMap extends Tilemap {
             add_tileset({
 
                 name : _tileset.name,
-                texture : Luxe.loadTexture( options.asset_path + _tileset.texture_name),
+                texture : Luxe.loadTexture( Path.normalize( options.asset_path + _tileset.texture_name ) ),
                 first_id : _tileset.first_id,
                 tile_width : _tileset.tile_width,
                 tile_height : _tileset.tile_height,


### PR DESCRIPTION
Use Path.normalize when resolving TiledMap texture path, so that path
navigation symbols (e.g. "..") will be handled correctly.
