### PR TITLE
Temporary fix for links to all dependencies

### DIFF
--- a/luxe/md/setup.md
+++ b/luxe/md/setup.md
@@ -82,6 +82,8 @@ For example, on ubuntu 12+ you could use `sudo apt-get install git-core`.
 
 [ ![deps](images/deps.png) ](http://luxeengine.com/)
 
+[flow](https://github.com/underscorediscovery/flow) | [snow] (https://github.com/underscorediscovery/snow) | [luxe] (https://github.com/underscorediscovery/luxe)
+
 This process is the same for all 3 libraries.   
 This process is easiest using the github app for Windows/Mac.
 


### PR DESCRIPTION
Added a temporary fix linking to all three dependencies.

I've also split the main dependency image into three seperate, as this is the end goal of what the links would look like, instead of text links.

![depsf](https://cloud.githubusercontent.com/assets/791577/4595111/e49b9532-5095-11e4-94fe-03e5b153c685.png)![depsl](https://cloud.githubusercontent.com/assets/791577/4595113/e4b13b8a-5095-11e4-8568-b2a26c89aabe.png)![depss](https://cloud.githubusercontent.com/assets/791577/4595114/e4c63e18-5095-11e4-9a10-47bd89a66f0a.png)
