### PR TITLE
Docs; #123 - fixed doc pages fading to oblivion 

### DIFF
--- a/luxe/tween/Actuate.hx
+++ b/luxe/tween/Actuate.hx
@@ -1,5 +1,5 @@
 /**
- * @author Joshua Granick
+  @author Joshua Granick   
  */
 package luxe.tween;
 
@@ -20,12 +20,12 @@ class Actuate {
 
 
     /**
-     * Copies properties from one object to another. Conflicting tweens are stopped automatically
-     * @example     <code>Actuate.apply (MyClip, { alpha: 1 } );</code>
-     * @param   target      The object to copy to
-     * @param   properties      The object to copy from
-     * @param   customActuator      A custom actuator to use instead of the default (Optional)
-     * @return      The current actuator instance, which can be used to apply properties like onComplete or onUpdate handlers
+      Copies properties from one object to another. Conflicting tweens are stopped automatically   
+      @example     <code>Actuate.apply (MyClip, { alpha: 1 } );</code>   
+      @param   target      The object to copy to   
+      @param   properties      The object to copy from   
+      @param   customActuator      A custom actuator to use instead of the default (Optional)   
+      @return      The current actuator instance, which can be used to apply properties like onComplete or onUpdate handlers   
      */
     public static function apply (target:Dynamic, properties:Dynamic, customActuator:Class <GenericActuator> = null):IGenericActuator {
 
@@ -59,12 +59,12 @@ class Actuate {
 
 
     /**
-     * Creates a new MotionPath tween
-     * @param   target      The object to tween
-     * @param   duration        The length of the tween in seconds
-     * @param   properties      An object containing a motion path for each property you wish to tween
-     * @param   overwrite       Sets whether previous tweens for the same target and properties will be overwritten (Default is true)
-     * @return      The current actuator instance, which can be used to apply properties like ease, delay, onComplete or onUpdate
+      Creates a new MotionPath tween   
+      @param   target      The object to tween   
+      @param   duration        The length of the tween in seconds   
+      @param   properties      An object containing a motion path for each property you wish to tween   
+      @param   overwrite       Sets whether previous tweens for the same target and properties will be overwritten (Default is true)   
+      @return      The current actuator instance, which can be used to apply properties like ease, delay, onComplete or onUpdate   
      */
     public static function motionPath (target:Dynamic, duration:Float, properties:Dynamic, overwrite:Bool = true):IGenericActuator {
 
@@ -74,8 +74,8 @@ class Actuate {
 
 
     /**
-     * Pauses tweens for the specified target objects
-     * @param   ... targets     The target objects which will have their tweens paused. Passing no value pauses tweens for all objects
+      Pauses tweens for the specified target objects   
+      @param   ... targets     The target objects which will have their tweens paused. Passing no value pauses tweens for all objects   
      */
     //public static function pause (... targets:Array):void {
     public static function pause (target:Dynamic):Void {
@@ -119,7 +119,7 @@ class Actuate {
 
 
     /**
-     * Resets Actuate by stopping and removing tweens for all objects
+      Resets Actuate by stopping and removing tweens for all objects   
      */
     public static function reset ():Void {
 
@@ -139,8 +139,8 @@ class Actuate {
 
 
     /**
-     * Resumes paused tweens for the specified target objects
-     * @param   ... targets     The target objects which will have their tweens resumed. Passing no value resumes tweens for all objects
+      Resumes paused tweens for the specified target objects   
+      @param   ... targets     The target objects which will have their tweens resumed. Passing no value resumes tweens for all objects   
      */
     public static function resume (target:Dynamic):Void {
 
@@ -183,11 +183,11 @@ class Actuate {
 
 
     /**
-     * Stops all tweens for an individual object
-     * @param   target      The target object which will have its tweens stopped, or a generic actuator instance
-     * @param   properties      A string, array or object which contains the properties you wish to stop, like "alpha", [ "x", "y" ] or { alpha: null }. Passing no value removes all tweens for the object (Optional)
-     * @param   complete        If tweens should apply their final target values before stopping. Default is false (Optional)
-     * @param   sendEvent   If a complete() event should be dispatched for the specified target. Default is true (Optional)
+      Stops all tweens for an individual object   
+      @param   target      The target object which will have its tweens stopped, or a generic actuator instance   
+      @param   properties      A string, array or object which contains the properties you wish to stop, like "alpha", [ "x", "y" ] or { alpha: null }. Passing no value removes all tweens for the object (Optional)   
+      @param   complete        If tweens should apply their final target values before stopping. Default is false (Optional)   
+      @param   sendEvent   If a complete() event should be dispatched for the specified target. Default is true (Optional)   
      */
     public static function stop (target:Dynamic, properties:Dynamic = null, complete:Bool = false, sendEvent:Bool = true):Void {
 
@@ -239,11 +239,11 @@ class Actuate {
 
 
     /**
-     * Creates a tween-based timer, which is useful for synchronizing function calls with other animations
-     * @example     <code>Actuate.timer (1).onComplete (trace, [ "Timer is now complete" ]);</code>
-     * @param   duration        The length of the timer in seconds
-     * @param   customActuator      A custom actuator to use instead of the default (Optional)
-     * @return      The current actuator instance, which can be used to apply properties like onComplete or to gain a reference to the target timer object
+      Creates a tween-based timer, which is useful for synchronizing function calls with other animations   
+      @example     <code>Actuate.timer (1).onComplete (trace, [ "Timer is now complete" ]);</code>   
+      @param   duration        The length of the timer in seconds   
+      @param   customActuator      A custom actuator to use instead of the default (Optional)   
+      @return      The current actuator instance, which can be used to apply properties like onComplete or to gain a reference to the target timer object   
      */
     public static function timer (duration:Float, customActuator:Class <GenericActuator> = null):IGenericActuator {
 
@@ -254,14 +254,14 @@ class Actuate {
 
 
     /**
-     * Creates a new tween
-     * @example     <code>Actuate.tween (MyClip, 1, { alpha: 1 } ).onComplete (trace, [ "MyClip is now visible" ]);</code>
-     * @param   target      The object to tween
-     * @param   duration        The length of the tween in seconds
-     * @param   properties      The end values to tween the target to
-     * @param   overwrite           Sets whether previous tweens for the same target and properties will be overwritten (Default is true)
-     * @param   customActuator      A custom actuator to use instead of the default (Optional)
-     * @return      The current actuator instance, which can be used to apply properties like ease, delay, onComplete or onUpdate
+      Creates a new tween   
+      @example     <code>Actuate.tween (MyClip, 1, { alpha: 1 } ).onComplete (trace, [ "MyClip is now visible" ]);</code>   
+      @param   target      The object to tween   
+      @param   duration        The length of the tween in seconds   
+      @param   properties      The end values to tween the target to   
+      @param   overwrite           Sets whether previous tweens for the same target and properties will be overwritten (Default is true)   
+      @param   customActuator      A custom actuator to use instead of the default (Optional)   
+      @return      The current actuator instance, which can be used to apply properties like ease, delay, onComplete or onUpdate   
      */
     public static function tween (target:Dynamic, duration:Float, properties:Dynamic, overwrite:Bool = true, customActuator:Class <GenericActuator> = null):IGenericActuator {
 
@@ -342,14 +342,14 @@ class Actuate {
 
 
     /**
-     * Creates a new tween that updates a method rather than setting the properties of an object
-     * @example     <code>Actuate.update (trace, 1, ["Value: ", 0], ["", 1]).onComplete (trace, [ "Finished tracing values between 0 and 1" ]);</code>
-     * @param   target      The method to update
-     * @param   duration        The length of the tween in seconds
-     * @param   start       The starting parameters of the method call. You may use both numeric and non-numeric values
-     * @param   end     The ending parameters of the method call. You may use both numeric and non-numeric values, but the signature should match the start parameters
-     * @param   overwrite       Sets whether previous tweens for the same target and properties will be overwritten (Default is true)
-     * @return      The current actuator instance, which can be used to apply properties like ease, delay, onComplete or onUpdate
+      Creates a new tween that updates a method rather than setting the properties of an object   
+      @example     <code>Actuate.update (trace, 1, ["Value: ", 0], ["", 1]).onComplete (trace, [ "Finished tracing values between 0 and 1" ]);</code>   
+      @param   target      The method to update   
+      @param   duration        The length of the tween in seconds   
+      @param   start       The starting parameters of the method call. You may use both numeric and non-numeric values   
+      @param   end     The ending parameters of the method call. You may use both numeric and non-numeric values, but the signature should match the start parameters   
+      @param   overwrite       Sets whether previous tweens for the same target and properties will be overwritten (Default is true)   
+      @return      The current actuator instance, which can be used to apply properties like ease, delay, onComplete or onUpdate   
      */
     public static function update (target:Dynamic, duration:Float, start:Array <Dynamic> = null, end:Array <Dynamic> = null, overwrite:Bool = true):IGenericActuator {
 

--- a/luxe/tween/MotionPath.hx
+++ b/luxe/tween/MotionPath.hx
@@ -2,8 +2,8 @@ package luxe.tween;
 
 
 /**
- * @author Joshua Granick
- * @author Aleš Tomeček (for RotationPath)
+  @author Joshua Granick   
+  @author Aleš Tomeček (for RotationPath)   
  */
 class MotionPath {
 
@@ -28,13 +28,13 @@ class MotionPath {
 
 
     /**
-     * Adds a bezier curve to the current motion path
-     * @param   x       The x position of the end point for the curve
-     * @param   y       The y position of the end point for the curve
-     * @param   controlX        The x position of the control point for the curve, which affects the angle and midpoint
-     * @param   controlX        The x position of the control point for the curve, which affects the angle and midpoint
-     * @param   strength        The degree of emphasis that should be placed on this segment. If a motion path contains multiple segments with the same strength, they all receive equal emphasis (Default is 1)
-     * @return      The current motion path instance
+      Adds a bezier curve to the current motion path   
+      @param   x       The x position of the end point for the curve   
+      @param   y       The y position of the end point for the curve   
+      @param   controlX        The x position of the control point for the curve, which affects the angle and midpoint   
+      @param   controlX        The x position of the control point for the curve, which affects the angle and midpoint   
+      @param   strength        The degree of emphasis that should be placed on this segment. If a motion path contains multiple segments with the same strength, they all receive equal emphasis (Default is 1)   
+      @return      The current motion path instance   
      */
     public function bezier (x:Float, y:Float, controlX:Float, controlY:Float, strength:Float = 1):MotionPath {
 
@@ -47,11 +47,11 @@ class MotionPath {
 
 
     /**
-     * Adds a line to the current motion path
-     * @param   x       The x position of the end point for the line
-     * @param   x       The y position of the end point for the line
-     * @param   strength        The degree of emphasis that should be placed on this segment . If a motion path contains multiple segments with the same strength, they all receive equal emphasis (Default is 1)
-     * @return      The current motion path instance
+      Adds a line to the current motion path   
+      @param   x       The x position of the end point for the line   
+      @param   x       The y position of the end point for the line   
+      @param   strength        The degree of emphasis that should be placed on this segment . If a motion path contains multiple segments with the same strength, they all receive equal emphasis (Default is 1)   
+      @return      The current motion path instance   
      */
     public function line (x:Float, y:Float, strength:Float = 1):MotionPath {
 

--- a/luxe/tween/actuators/GenericActuator.hx
+++ b/luxe/tween/actuators/GenericActuator.hx
@@ -1,6 +1,6 @@
 /**
- * @author Joshua Granick
- * @version 1.2
+  @author Joshua Granick   
+  @version 1.2   
  */
 
 
@@ -77,9 +77,9 @@ class GenericActuator implements IGenericActuator {
 
 
     /**
-     * Sometimes drawing performs faster when objects are set to visible = false rather than only alpha = 0. autoVisible toggles automatically based on alpha values
-     * @param   value       Whether autoVisible should be enabled (Default is true)
-     * @return      The current actuator instance
+      Sometimes drawing performs faster when objects are set to visible = false rather than only alpha = 0. autoVisible toggles automatically based on alpha values   
+      @param   value       Whether autoVisible should be enabled (Default is true)   
+      @return      The current actuator instance   
      */
     public function autoVisible (?value:Null<Bool>):IGenericActuator {
 
@@ -158,9 +158,9 @@ class GenericActuator implements IGenericActuator {
 
 
     /**
-     * Increases the delay before a tween is executed
-     * @param   duration        The amount of seconds to delay
-     * @return      The current actuator instance
+      Increases the delay before a tween is executed   
+      @param   duration        The amount of seconds to delay   
+      @return      The current actuator instance   
      */
     public function delay (duration:Float):IGenericActuator {
 
@@ -172,9 +172,9 @@ class GenericActuator implements IGenericActuator {
 
 
     /**
-     * Sets the easing which is used when running the tween
-     * @param   easing      An easing equation, like Elastic.easeIn or Quad.easeOut
-     * @return      The current actuator instance
+      Sets the easing which is used when running the tween   
+      @param   easing      An easing equation, like Elastic.easeIn or Quad.easeOut   
+      @return      The current actuator instance   
      */
     public function ease (easing:IEasing):IGenericActuator {
 
@@ -193,9 +193,9 @@ class GenericActuator implements IGenericActuator {
 
 
     /**
-     * Specify whether this should be scaled by the global timescale
-     * @param   _value      Whether or not it should be
-     * @return      The current actuator instance
+      Specify whether this should be scaled by the global timescale   
+      @param   _value      Whether or not it should be   
+      @return      The current actuator instance   
      */
 
     public var timescaled : Bool = false;
@@ -205,10 +205,10 @@ class GenericActuator implements IGenericActuator {
     }
 
     /**
-     * Defines a function which will be called when the tween finishes
-     * @param   handler     The function you would like to be called
-     * @param   parameters      Parameters you would like to pass to the handler function when it is called
-     * @return      The current actuator instance
+      Defines a function which will be called when the tween finishes   
+      @param   handler     The function you would like to be called   
+      @param   parameters      Parameters you would like to pass to the handler function when it is called   
+      @return      The current actuator instance   
      */
     public function onComplete (handler:Dynamic, parameters:Array <Dynamic> = null):IGenericActuator {
 
@@ -236,10 +236,10 @@ class GenericActuator implements IGenericActuator {
 
 
     /**
-     * Defines a function which will be called when the tween repeats
-     * @param   handler     The function you would like to be called
-     * @param   parameters      Parameters you would like to pass to the handler function when it is called
-     * @return      The current actuator instance
+      Defines a function which will be called when the tween repeats   
+      @param   handler     The function you would like to be called   
+      @param   parameters      Parameters you would like to pass to the handler function when it is called   
+      @return      The current actuator instance   
      */
     public function onRepeat (handler:Dynamic, parameters:Array <Dynamic> = null):IGenericActuator {
 
@@ -261,10 +261,10 @@ class GenericActuator implements IGenericActuator {
 
 
     /**
-     * Defines a function which will be called when the tween updates
-     * @param   handler     The function you would like to be called
-     * @param   parameters      Parameters you would like to pass to the handler function when it is called
-     * @return      The current actuator instance
+      Defines a function which will be called when the tween updates   
+      @param   handler     The function you would like to be called   
+      @param   parameters      Parameters you would like to pass to the handler function when it is called   
+      @return      The current actuator instance   
      */
     public function onUpdate (handler:Dynamic, parameters:Array <Dynamic> = null):IGenericActuator {
 
@@ -293,9 +293,9 @@ class GenericActuator implements IGenericActuator {
 
 
     /**
-     * Automatically changes the reverse value when the tween repeats. Repeat must be enabled for this to have any effect
-     * @param   value       Whether reflect should be enabled (Default is true)
-     * @return      The current actuator instance
+      Automatically changes the reverse value when the tween repeats. Repeat must be enabled for this to have any effect   
+      @param   value       Whether reflect should be enabled (Default is true)   
+      @return      The current actuator instance   
      */
     public function reflect (?value:Null<Bool>):IGenericActuator {
 
@@ -314,9 +314,9 @@ class GenericActuator implements IGenericActuator {
 
 
     /**
-     * Repeats the tween after it finishes
-     * @param   times       The number of times you would like the tween to repeat, or -1 if you would like to repeat the tween indefinitely (Default is -1)
-     * @return      The current actuator instance
+      Repeats the tween after it finishes   
+      @param   times       The number of times you would like the tween to repeat, or -1 if you would like to repeat the tween indefinitely (Default is -1)   
+      @return      The current actuator instance   
      */
     public function repeat (?times:Null<Int>):IGenericActuator {
 
@@ -341,9 +341,9 @@ class GenericActuator implements IGenericActuator {
 
 
     /**
-     * Sets if the tween should be handled in reverse
-     * @param   value       Whether the tween should be reversed (Default is true)
-     * @return      The current actuator instance
+      Sets if the tween should be handled in reverse   
+      @param   value       Whether the tween should be reversed (Default is true)   
+      @return      The current actuator instance   
      */
     public function reverse (?value:Null<Bool>):IGenericActuator {
 
@@ -362,9 +362,9 @@ class GenericActuator implements IGenericActuator {
 
 
     /**
-     * Enabling smartRotation can prevent undesired results when tweening rotation values
-     * @param   value       Whether smart rotation should be enabled (Default is true)
-     * @return      The current actuator instance
+      Enabling smartRotation can prevent undesired results when tweening rotation values   
+      @param   value       Whether smart rotation should be enabled (Default is true)   
+      @return      The current actuator instance   
      */
     public function smartRotation (?value:Null<Bool>):IGenericActuator {
 
@@ -383,9 +383,9 @@ class GenericActuator implements IGenericActuator {
 
 
     /**
-     * Snapping causes tween values to be rounded automatically
-     * @param   value       Whether tween values should be rounded (Default is true)
-     * @return      The current actuator instance
+      Snapping causes tween values to be rounded automatically   
+      @param   value       Whether tween values should be rounded (Default is true)   
+      @return      The current actuator instance   
      */
     public function snapping (?value:Null<Bool>):IGenericActuator {
 
@@ -416,89 +416,89 @@ class GenericActuator implements IGenericActuator {
 @:noCompletion interface IGenericActuator {
 
     /**
-     * Flash performs faster when objects are set to visible = false rather than only alpha = 0. autoVisible toggles automatically based on alpha values
-     * @param   value       Whether autoVisible should be enabled (Default is true)
-     * @return      The current actuator instance
+      Flash performs faster when objects are set to visible = false rather than only alpha = 0. autoVisible toggles automatically based on alpha values   
+      @param   value       Whether autoVisible should be enabled (Default is true)   
+      @return      The current actuator instance   
      */
     public function autoVisible (?value:Null<Bool>):IGenericActuator;
 
     /**
-     * Increases the delay before a tween is executed
-     * @param   duration        The amount of seconds to delay
-     * @return      The current actuator instance
+      Increases the delay before a tween is executed   
+      @param   duration        The amount of seconds to delay   
+      @return      The current actuator instance   
      */
     public function delay (duration:Float):IGenericActuator;
 
     /**
-     * Sets the easing which is used when running the tween
-     * @param   easing      An easing equation, like Elastic.easeIn or Quad.easeOut
-     * @return      The current actuator instance
+      Sets the easing which is used when running the tween   
+      @param   easing      An easing equation, like Elastic.easeIn or Quad.easeOut   
+      @return      The current actuator instance   
      */
     public function ease (easing:IEasing):IGenericActuator;
 
     /**
-     * Defines a function which will be called when the tween finishes
-     * @param   handler     The function you would like to be called
-     * @param   parameters      Parameters you would like to pass to the handler function when it is called
-     * @return      The current actuator instance
+      Defines a function which will be called when the tween finishes   
+      @param   handler     The function you would like to be called   
+      @param   parameters      Parameters you would like to pass to the handler function when it is called   
+      @return      The current actuator instance   
      */
     public function onComplete (handler:Dynamic, ?parameters:Array <Dynamic>):IGenericActuator;
 
     /**
-     * Defines a function which will be called when the tween repeats
-     * @param   handler     The function you would like to be called
-     * @param   parameters      Parameters you would like to pass to the handler function when it is called
-     * @return      The current actuator instance
+      Defines a function which will be called when the tween repeats   
+      @param   handler     The function you would like to be called   
+      @param   parameters      Parameters you would like to pass to the handler function when it is called   
+      @return      The current actuator instance   
      */
     public function onRepeat (handler:Dynamic, ?parameters:Array <Dynamic>):IGenericActuator;
 
     /**
-     * Defines a function which will be called when the tween updates
-     * @param   handler     The function you would like to be called
-     * @param   parameters      Parameters you would like to pass to the handler function when it is called
-     * @return      The current actuator instance
+      Defines a function which will be called when the tween updates   
+      @param   handler     The function you would like to be called   
+      @param   parameters      Parameters you would like to pass to the handler function when it is called   
+      @return      The current actuator instance   
      */
     public function onUpdate (handler:Dynamic, ?parameters:Array <Dynamic>):IGenericActuator;
 
     /**
-     * Automatically changes the reverse value when the tween repeats. Repeat must be enabled for this to have any effect
-     * @param   value       Whether reflect should be enabled (Default is true)
-     * @return      The current actuator instance
+      Automatically changes the reverse value when the tween repeats. Repeat must be enabled for this to have any effect   
+      @param   value       Whether reflect should be enabled (Default is true)   
+      @return      The current actuator instance   
      */
     public function reflect (?value:Null<Bool>):IGenericActuator;
 
     /**
-     * Repeats the tween after it finishes
-     * @param   times       The number of times you would like the tween to repeat, or -1 if you would like to repeat the tween indefinitely (Default is -1)
-     * @return      The current actuator instance
+      Repeats the tween after it finishes   
+      @param   times       The number of times you would like the tween to repeat, or -1 if you would like to repeat the tween indefinitely (Default is -1)   
+      @return      The current actuator instance   
      */
     public function repeat (?times:Null<Int>):IGenericActuator;
 
     /**
-     * Sets if the tween should be handled in reverse
-     * @param   value       Whether the tween should be reversed (Default is true)
-     * @return      The current actuator instance
+      Sets if the tween should be handled in reverse   
+      @param   value       Whether the tween should be reversed (Default is true)   
+      @return      The current actuator instance   
      */
     public function reverse (?value:Null<Bool>):IGenericActuator;
 
     /**
-     * Specify whether this should be scaled by the global timescale
-     * @param   _value      Whether or not it should be
-     * @return      The current actuator instance
+      Specify whether this should be scaled by the global timescale   
+      @param   _value      Whether or not it should be   
+      @return      The current actuator instance   
      */
 
     public function timescale( _value:Bool = true ):IGenericActuator;
     /**
-     * Enabling smartRotation can prevent undesired results when tweening rotation values
-     * @param   value       Whether smart rotation should be enabled (Default is true)
-     * @return      The current actuator instance
+      Enabling smartRotation can prevent undesired results when tweening rotation values   
+      @param   value       Whether smart rotation should be enabled (Default is true)   
+      @return      The current actuator instance   
      */
     public function smartRotation (?value:Null<Bool>):IGenericActuator;
 
     /**
-     * Snapping causes tween values to be rounded automatically
-     * @param   value       Whether tween values should be rounded (Default is true)
-     * @return      The current actuator instance
+      Snapping causes tween values to be rounded automatically   
+      @param   value       Whether tween values should be rounded (Default is true)   
+      @return      The current actuator instance   
      */
     public function snapping (?value:Null<Bool>):IGenericActuator;
 

--- a/luxe/tween/actuators/SimpleActuator.hx
+++ b/luxe/tween/actuators/SimpleActuator.hx
@@ -12,8 +12,8 @@ import haxe.Timer;
 
 
 /**
- * @author Joshua Granick
- * @version 1.2
+  @author Joshua Granick   
+  @version 1.2   
  */
 class SimpleActuator extends GenericActuator {
 
@@ -66,7 +66,7 @@ class SimpleActuator extends GenericActuator {
 
 
     /**
-     * @inheritDoc
+      @inheritDoc   
      */
     public override function autoVisible (?value:Null<Bool>):IGenericActuator {
 
@@ -96,7 +96,7 @@ class SimpleActuator extends GenericActuator {
 
 
     /**
-     * @inheritDoc
+      @inheritDoc   
      */
     public override function delay (duration:Float):IGenericActuator {
 
@@ -186,7 +186,7 @@ class SimpleActuator extends GenericActuator {
 
 
     /**
-     * @inheritDoc
+      @inheritDoc   
      */
     public override function onUpdate (handler:Dynamic, parameters:Array <Dynamic> = null):IGenericActuator {
 

--- a/luxe/utils/JSON.hx
+++ b/luxe/utils/JSON.hx
@@ -43,40 +43,40 @@ import luxe.utils.json.JSONEncoder;
 class JSON {
 
 	/**
-	 * Encodes a object into a JSON string.
-	 *
-	 * @param o The object to create a JSON string for
-	 * @return the JSON string representing o
+	  Encodes a object into a JSON string.   
+	    
+	  @param o The object to create a JSON string for   
+	  @return the JSON string representing o   
 	 */
 	public inline static function encode(o:Dynamic):String {		
 		return new JSONEncoder(o).getString();
 	} //encode
 	
 	/**
-	 * Decodes a JSON string into a native object.
-	 * 
-	 * @param s The JSON string representing the object
-	 * @return A native object as specified by s
+	  Decodes a JSON string into a native object.   
+	     
+	  @param s The JSON string representing the object   
+	  @return A native object as specified by s   
 	 */
 	public inline static function decode(s:String,strict:Bool=true):Dynamic {		
 		return new JSONDecoder(s,strict).getValue();
 	} //decode
 	
 	/**
-	 * Encodes a object into a JSON string.
-	 *
-	 * @param o The object to create a JSON string for
-	 * @return the JSON string representing o
+	  Encodes a object into a JSON string.   
+	    
+	  @param o The object to create a JSON string for   
+	  @return the JSON string representing o   
 	 */
 	public inline static function stringify(o:Dynamic):String {			
 		return new JSONEncoder(o).getString();
 	} //stringify
 	
 	/**
-	 * Decodes a JSON string into a native object.
-	 * 
-	 * @param s The JSON string representing the object
-	 * @return A native object as specified by s
+	  Decodes a JSON string into a native object.   
+	     
+	  @param s The JSON string representing the object   
+	  @return A native object as specified by s   
 	 */
 	public inline static function parse(s:String,strict:Bool=false):Dynamic {		
 		return new JSONDecoder(s,strict).getValue();

--- a/luxe/utils/json/JSONDecoder.hx
+++ b/luxe/utils/json/JSONDecoder.hx
@@ -66,10 +66,10 @@ package luxe.utils.json;
     var token:JSONToken;
 
     /**
-     * Constructs a new JSONDecoder to parse a JSON string
-     * into a native object.
-     *
-     * @param s The JSON string to be converted into a native object
+      Constructs a new JSONDecoder to parse a JSON string   
+      into a native object.   
+        
+      @param s The JSON string to be converted into a native object   
      */
     public function new(s:String, strict:Bool) {
         this.strict = strict;
@@ -81,26 +81,26 @@ package luxe.utils.json;
     }
 
     /**
-     * Gets the internal object that was created by parsing
-     * the JSON string passed to the constructor.
-     *
-     * @return The internal object representation of the JSON
-     *      string that was passed to the constructor
+      Gets the internal object that was created by parsing   
+      the JSON string passed to the constructor.   
+        
+      @return The internal object representation of the JSON   
+           string that was passed to the constructor   
      */
     public function getValue():Dynamic {
         return value;
     }
 
     /**
-     * Returns the next token from the tokenzier reading
-     * the JSON string
+      Returns the next token from the tokenzier reading   
+      the JSON string   
      */
     function nextToken():JSONToken {
         return token = tokenizer.getNextToken();
     }
 
     /**
-     * Attempt to parse an array
+      Attempt to parse an array   
      */
     function parseArray():Array < Dynamic > {
         // create an array internally that we're going to attempt
@@ -155,7 +155,7 @@ package luxe.utils.json;
     }
 
     /**
-     * Attempt to parse an object
+      Attempt to parse an object   
      */
     function parseObject():Dynamic {
         // create the object internally that we're going to
@@ -230,7 +230,7 @@ package luxe.utils.json;
     }
 
     /**
-     * Attempt to parse a value
+      Attempt to parse a value   
      */
     function parseValue():Dynamic   {
         // Catch errors when the input stream ends abruptly

--- a/luxe/utils/json/JSONEncoder.hx
+++ b/luxe/utils/json/JSONEncoder.hx
@@ -48,19 +48,19 @@ import haxe.Utf8;
     var jsonString:String;
 
     /**
-     * Creates a new JSONEncoder.
-     *
-     * @param o The object to encode as a JSON string
+      Creates a new JSONEncoder.   
+        
+      @param o The object to encode as a JSON string   
      */
     public function new(value:Dynamic) {
         jsonString = convertToString(value);
     }
 
     /**
-     * Gets the JSON string from the encoder.
-     *
-     * @return The JSON string representation of the object
-     *      that was passed to the constructor
+      Gets the JSON string from the encoder.   
+        
+      @return The JSON string representation of the object   
+           that was passed to the constructor   
      */
     public function getString():String {
         return jsonString;
@@ -70,10 +70,10 @@ import haxe.Utf8;
     public function _trace(e) { if(debug) trace(e); }
 
     /**
-     * Converts a value to it's JSON string equivalent.
-     *
-     * @param value The value to convert.  Could be any
-     *      type (object, number, array, etc)
+      Converts a value to it's JSON string equivalent.   
+        
+      @param value The value to convert.  Could be any   
+           type (object, number, array, etc)   
      */
     function convertToString(value:Dynamic):String {
 
@@ -131,11 +131,11 @@ import haxe.Utf8;
     }
 
     /**
-     * Escapes a string accoding to the JSON specification.
-     *
-     * @param str The string to be escaped
-     * @return The string with escaped special characters
-     *      according to the JSON specification
+      Escapes a string accoding to the JSON specification.   
+        
+      @param str The string to be escaped   
+      @return The string with escaped special characters   
+           according to the JSON specification   
      */
     function escapeString( str:String ):String {
         // create a string to store the string's jsonstring value
@@ -217,10 +217,10 @@ import haxe.Utf8;
     }
 
     /**
-     * Converts an array to it's JSON string equivalent
-     *
-     * @param a The array to convert
-     * @return The JSON string representation of <code>a</code>
+      Converts an array to it's JSON string equivalent   
+        
+      @param a The array to convert   
+      @return The JSON string representation of <code>a</code>   
      */
     function arrayToString( a:Array < Dynamic > ):String {
         //trace("arrayToString");
@@ -260,10 +260,10 @@ import haxe.Utf8;
     }
 
     /**
-     * Converts an object to it's JSON string equivalent
-     *
-     * @param o The object to convert
-     * @return The JSON string representation of <code>o</code>
+      Converts an object to it's JSON string equivalent   
+        
+      @param o The object to convert   
+      @return The JSON string representation of <code>o</code>   
      */
     function objectToString(o:Dynamic):String {
         //trace("objectToString");
@@ -291,11 +291,11 @@ import haxe.Utf8;
     }
 
   /**
-   * Converts an instance object to it's JSON string equivalent
-   *
-   * @param o The instance object to convert
-   * @param cls The class of instance object
-   * @return The JSON string representation of <code>o</code>
+    Converts an instance object to it's JSON string equivalent   
+      
+    @param o The instance object to convert   
+    @param cls The class of instance object   
+    @return The JSON string representation of <code>o</code>   
    */
   function instanceToString (o : Dynamic, cls : Class <Dynamic>) : String {
     var s : String = "";

--- a/luxe/utils/json/JSONParseError.hx
+++ b/luxe/utils/json/JSONParseError.hx
@@ -48,9 +48,9 @@ package luxe.utils.json;
     var message:String;
 
     /**
-     * Constructs a new JSONParseError.
-     *
-     * @param message The error message that occured during parsing
+      Constructs a new JSONParseError.   
+        
+      @param message The error message that occured during parsing   
      */
     public function new(message:String = "",location:Int = 0,text:String = "") {
         //super( message );
@@ -61,18 +61,18 @@ package luxe.utils.json;
     }
 
     /**
-     * Provides read-only access to the location variable.
-     *
-     * @return The location in the string where the error occurred
+      Provides read-only access to the location variable.   
+        
+      @return The location in the string where the error occurred   
      */
     public function get_location():Int {
         return _location;
     }
 
     /**
-     * Provides read-only access to the text variable.
-     *
-     * @return The string in which the error occurred
+      Provides read-only access to the text variable.   
+        
+      @return The string in which the error occurred   
      */
     public function get_text():String {
         return _text;

--- a/luxe/utils/json/JSONToken.hx
+++ b/luxe/utils/json/JSONToken.hx
@@ -46,10 +46,10 @@ import luxe.utils.json.JSONDecoder;
   public var value:Dynamic;
   
   /**
-   * Creates a new JSONToken with a specific token type and value.
-   *
-   * @param type The JSONTokenType of the token
-   * @param value The value of the token
+    Creates a new JSONToken with a specific token type and value.   
+      
+    @param type The JSONTokenType of the token   
+    @param value The value of the token   
    */
   public function new(?type:JSONTokenType,?value:Dynamic = null) {
     this.type = type==null?tUNKNOWN:type;

--- a/luxe/utils/json/JSONTokenizer.hx
+++ b/luxe/utils/json/JSONTokenizer.hx
@@ -55,11 +55,11 @@ import haxe.Utf8;
     var strict:Bool;
 
     /**
-     * Constructs a new JSONDecoder to parse a JSON string
-     * into a native object.
-     *
-     * @param s The JSON string to be converted
-     *      into a native object
+      Constructs a new JSONDecoder to parse a JSON string   
+      into a native object.   
+        
+      @param s The JSON string to be converted   
+           into a native object   
      */
     public function new(s:String,strict:Bool) {
         jsonString = s;
@@ -70,8 +70,8 @@ import haxe.Utf8;
     }
 
     /**
-     * Gets the next token in the input sting and advances
-    * the character to the next character after the token
+      Gets the next token in the input sting and advances   
+      the character to the next character after the token   
      */
     public function getNextToken():JSONToken {
         var token:JSONToken = new JSONToken();
@@ -188,12 +188,12 @@ import haxe.Utf8;
     }
 
     /**
-     * Attempts to read a string from the input string.  Places
-     * the character location at the first character after the
-     * string.  It is assumed that ch is " before this method is called.
-     *
-     * @return the JSONToken with the string value if a string could
-     *      be read.  Throws an error otherwise.
+      Attempts to read a string from the input string.  Places   
+      the character location at the first character after the   
+      string.  It is assumed that ch is " before this method is called.   
+        
+      @return the JSONToken with the string value if a string could   
+           be read.  Throws an error otherwise.   
      */
     function readString():JSONToken {
         // the string to store the string we'll try to read
@@ -308,12 +308,12 @@ import haxe.Utf8;
     }
 
     /**
-     * Attempts to read a number from the input string.  Places
-     * the character location at the first character after the
-     * number.
-     *
-     * @return The JSONToken with the number value if a number could
-     *      be read.  Throws an error otherwise.
+      Attempts to read a number from the input string.  Places   
+      the character location at the first character after the   
+      number.   
+        
+      @return The JSONToken with the number value if a number could   
+           be read.  Throws an error otherwise.   
      */
     function readNumber():JSONToken {
         // the string to accumulate the number characters
@@ -418,19 +418,19 @@ import haxe.Utf8;
     }
 
     /**
-     * Reads the next character in the input
-     * string and advances the character location.
-     *
-     * @return The next character in the input string, or
-     *      null if we've read past the end.
+      Reads the next character in the input   
+      string and advances the character location.   
+        
+      @return The next character in the input string, or   
+           null if we've read past the end.   
      */
     function nextChar():String {
         return ch = jsonString.charAt( loc++ );
     }
 
     /**
-     * Advances the character location past any
-     * sort of white space and comments
+      Advances the character location past any   
+      sort of white space and comments   
      */
     function skipIgnored():Void {
         var originalLoc:Int;
@@ -444,9 +444,9 @@ import haxe.Utf8;
     }
 
     /**
-     * Skips comments in the input string, either
-     * single-line or multi-line.  Advances the character
-     * to the first position after the end of the comment.
+      Skips comments in the input string, either   
+      single-line or multi-line.  Advances the character   
+      to the first position after the end of the comment.   
      */
     function skipComments():Void {
         if ( ch == '/' ) {
@@ -493,9 +493,9 @@ import haxe.Utf8;
 
 
     /**
-     * Skip any whitespace in the input string and advances
-     * the character to the first character after any possible
-     * whitespace.
+      Skip any whitespace in the input string and advances   
+      the character to the first character after any possible   
+      whitespace.   
      */
     function skipWhite():Void {
         // As long as there are spaces in the input
@@ -507,19 +507,19 @@ import haxe.Utf8;
     }
 
     /**
-     * Determines if a character is whitespace or not.
-     *
-     * @return True if the character passed in is a whitespace
-     *  character
+      Determines if a character is whitespace or not.   
+        
+      @return True if the character passed in is a whitespace   
+       character   
      */
     function isWhiteSpace( ch:String ):Bool {
         return ( ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' );
     }
 
     /**
-     * Determines if a character is a digit [0-9].
-     *
-     * @return True if the character passed in is a digit
+      Determines if a character is a digit [0-9].   
+        
+      @return True if the character passed in is a digit   
      */
     function isDigit( ch:String ):Bool {
         #if php
@@ -530,9 +530,9 @@ import haxe.Utf8;
     }
 
     /**
-     * Determines if a character is a digit [0-9].
-     *
-     * @return True if the character passed in is a digit
+      Determines if a character is a digit [0-9].   
+        
+      @return True if the character passed in is a digit   
      */
     function isHexDigit( ch:String ):Bool {
         // get the uppercase value of ch so we only have
@@ -544,10 +544,10 @@ import haxe.Utf8;
     }
 
     /**
-     * Raises a parsing error with a specified message, tacking
-     * on the error location and the original string.
-     *
-     * @param message The message indicating why the error occurred
+      Raises a parsing error with a specified message, tacking   
+      on the error location and the original string.   
+        
+      @param message The message indicating why the error occurred   
      */
     public function parseError( message:String ):Void {
         throw new JSONParseError( message, loc, jsonString );


### PR DESCRIPTION
Cleaned up the docs code to fix #123. Found offending comments on:
tween/Actuate.hx
tween/MotionPath.hx
tween/actuators/GenericActuator.hx
tween/actuators/SimpleActuator.hx
utils/JSON.hx
utils/json/JSONDecoder.hx
utils/json/JSONEncoder.hx
utils/json/JSONParseError.hx
utils/json/JSONToken.hx
utils/json/JSONTokenizer.hx
