### PR TITLE
MeshComponent; destroys its mesh when parent is destroyed

### DIFF
--- a/luxe/components/render/MeshComponent.hx
+++ b/luxe/components/render/MeshComponent.hx
@@ -65,6 +65,12 @@ class MeshComponent extends Component {
 
     override function update(dt:Float) {
 
-    }
+    } // update
+    
+    override function ondestroy() {
+        if(mesh != null) {
+            mesh.destroy();
+        }
+    } // ondestroy
 
 } //MeshComponent


### PR DESCRIPTION
MeshComponent now destroys it's mesh when the parent entity is destroyed. Code tested locally.
