### PR TITLE
Nineslice improvements

### DIFF
--- a/luxe/NineSlice.hx
+++ b/luxe/NineSlice.hx
@@ -120,88 +120,88 @@ class NineSlice extends luxe.Visual {
         midwidth = Math.abs(width - left - right);
         midheight = Math.abs(height - top - bottom);
 
-            //top left
-            slices[0].source_width  = left;
-            slices[0].source_height = top;
-            slices[0].source_x = source_x;
-            slices[0].source_y = source_y;
-            slices[0].pos.set_xy(0,0);
-            slices[0].width = left;
-            slices[0].height = top;
+        //top left
+        slices[0].source_width  = left;
+        slices[0].source_height = top;
+        slices[0].source_x = source_x;
+        slices[0].source_y = source_y;
+        slices[0].pos.set_xy(0,0);
+        slices[0].width = left;
+        slices[0].height = top;
 
-            //top middle
-            slices[1].source_width  = source_w - left - right;
-            slices[1].source_height = top;
-            slices[1].source_x = source_x+left;
-            slices[1].source_y = source_y;
-            slices[1].pos.set_xy(left,0);
-            slices[1].width = width - left - right;
-            slices[1].height = top;
+        //top middle
+        slices[1].source_width  = source_w - left - right;
+        slices[1].source_height = top;
+        slices[1].source_x = source_x+left;
+        slices[1].source_y = source_y;
+        slices[1].pos.set_xy(left,0);
+        slices[1].width = width - left - right;
+        slices[1].height = top;
 
-            //top right
-            slices[2].source_width  = right;
-            slices[2].source_height = top;
-            slices[2].source_x = source_x+ (source_w - right);
-            slices[2].source_y = source_y;
-            slices[2].pos.set_xy(left + midwidth,0);
-            slices[2].width = right;
-            slices[2].height = top;
-
-
-            //middle left
-            slices[3].source_width  = left;
-            slices[3].source_height = source_h - top - bottom;
-            slices[3].source_x = source_x;
-            slices[3].source_y = source_y+top;
-            slices[3].pos.set_xy(0,top);
-            slices[3].width = left;
-            slices[3].height = height - top - bottom;
-
-            //middle middle
-            slices[4].source_width  = source_w - left - right;
-            slices[4].source_height = source_h - top - bottom;
-            slices[4].source_x = source_x+left;
-            slices[4].source_y = source_y+top;
-            slices[4].pos.set_xy(left,top);
-            slices[4].width = width - left - right;
-            slices[4].height = height - top - bottom;
-
-            //middle right
-            slices[5].source_width  = right;
-            slices[5].source_height = source_h - top - bottom;
-            slices[5].source_x = source_x+(source_w - right);
-            slices[5].source_y = source_y+top;
-            slices[5].pos.set_xy(left + midwidth,top);
-            slices[5].width = right;
-            slices[5].height = height - top - bottom;
+        //top right
+        slices[2].source_width  = right;
+        slices[2].source_height = top;
+        slices[2].source_x = source_x+ (source_w - right);
+        slices[2].source_y = source_y;
+        slices[2].pos.set_xy(left + midwidth,0);
+        slices[2].width = right;
+        slices[2].height = top;
 
 
-            //bottom left
-            slices[6].source_width  = left;
-            slices[6].source_height = bottom;
-            slices[6].source_x = source_x;
-            slices[6].source_y = source_y+ (source_h - bottom);
-            slices[6].pos.set_xy(0,top + midheight);
-            slices[6].width = left;
-            slices[6].height = bottom;
+        //middle left
+        slices[3].source_width  = left;
+        slices[3].source_height = source_h - top - bottom;
+        slices[3].source_x = source_x;
+        slices[3].source_y = source_y+top;
+        slices[3].pos.set_xy(0,top);
+        slices[3].width = left;
+        slices[3].height = height - top - bottom;
 
-            //bottom middle
-            slices[7].source_width  = source_w - left - right;
-            slices[7].source_height = bottom;
-            slices[7].source_x = source_x+left;
-            slices[7].source_y = source_y+(source_h - bottom);
-            slices[7].pos.set_xy(left,top + midheight);
-            slices[7].width = width - left - right;
-            slices[7].height = bottom;
+        //middle middle
+        slices[4].source_width  = source_w - left - right;
+        slices[4].source_height = source_h - top - bottom;
+        slices[4].source_x = source_x+left;
+        slices[4].source_y = source_y+top;
+        slices[4].pos.set_xy(left,top);
+        slices[4].width = width - left - right;
+        slices[4].height = height - top - bottom;
 
-            //bottom right
-            slices[8].source_width  = right;
-            slices[8].source_height = bottom;
-            slices[8].source_x = source_x+(source_w - right);
-            slices[8].source_y = source_y+(source_h - bottom);
-            slices[8].pos.set_xy(left + midwidth, top + midheight);
-            slices[8].width = right;
-            slices[8].height = bottom;
+        //middle right
+        slices[5].source_width  = right;
+        slices[5].source_height = source_h - top - bottom;
+        slices[5].source_x = source_x+(source_w - right);
+        slices[5].source_y = source_y+top;
+        slices[5].pos.set_xy(left + midwidth,top);
+        slices[5].width = right;
+        slices[5].height = height - top - bottom;
+
+
+        //bottom left
+        slices[6].source_width  = left;
+        slices[6].source_height = bottom;
+        slices[6].source_x = source_x;
+        slices[6].source_y = source_y+ (source_h - bottom);
+        slices[6].pos.set_xy(0,top + midheight);
+        slices[6].width = left;
+        slices[6].height = bottom;
+
+        //bottom middle
+        slices[7].source_width  = source_w - left - right;
+        slices[7].source_height = bottom;
+        slices[7].source_x = source_x+left;
+        slices[7].source_y = source_y+(source_h - bottom);
+        slices[7].pos.set_xy(left,top + midheight);
+        slices[7].width = width - left - right;
+        slices[7].height = bottom;
+
+        //bottom right
+        slices[8].source_width  = right;
+        slices[8].source_height = bottom;
+        slices[8].source_x = source_x+(source_w - right);
+        slices[8].source_y = source_y+(source_h - bottom);
+        slices[8].pos.set_xy(left + midwidth, top + midheight);
+        slices[8].width = right;
+        slices[8].height = bottom;
 
     } //update_size
 
@@ -220,6 +220,7 @@ class NineSlice extends luxe.Visual {
         midwidth = Math.abs(width - left - right);
         midheight = Math.abs(height - top - bottom);
 
+            //top left
         slices.push({
             source_width  : left,
             source_height : top,

--- a/luxe/NineSlice.hx
+++ b/luxe/NineSlice.hx
@@ -24,7 +24,7 @@ private typedef Slice = {
 };
 
 /** A nineslice based sprite, for scaling */
-class NineSlice extends luxe.Sprite {
+class NineSlice extends luxe.Visual {
 
     public var top : Float = 32;
     public var left : Float = 32;
@@ -343,74 +343,6 @@ class NineSlice extends luxe.Sprite {
 
     } //set_size
 
-    override function set_pos( _v : Vector ) {
-
-        super.set_pos(_v);
-
-        var _pv = _v.clone();
-
-        if(is_set) {
-            _geometry.transform.pos = _pv;
-        }
-
-        return super.set_pos(_pv);
-
-    } //set_pos
-
-    override function ondestroy() {
-
-        if(is_set) {
-            _geometry.drop();
-        }
-
-    } //ondestroy
-
-    override function set_visible(_v:Bool) {
-
-        super.set_visible(_v);
-
-        if(is_set) {
-            _geometry.visible = _v;
-        }
-
-        return visible = _v;
-
-    } //set_visible
-
-    override function set_depth(_d:Float) {
-
-        super.set_depth(_d);
-
-        if(is_set) {
-            _geometry.depth = _d;
-        }
-
-        return depth = _d;
-
-    } //set_depth
-
-//Clip rect
-    override function set_clip_rect(val : Rectangle) : Rectangle {
-
-        if(is_set) {
-            _geometry.clip_rect = val;
-        }
-
-        return clip_rect = val;
-
-    } //set_clip_rect
-
-//Color
-    override function set_color(_color : Color) : Color {
-
-        if(is_set) {
-            _geometry.color = _color;
-        }
-
-        return color = _color;
-
-    } //set_color
-
     function _create(_pos:Vector, _w:Float, _h:Float, ?_reset:Bool = false) {
 
         if(!is_set || _reset) {
@@ -445,6 +377,7 @@ class NineSlice extends luxe.Sprite {
 
         _geometry.transform.pos = _pos;
         _geometry.id = 'NineSlice' + _geometry.id;
+        geometry = _geometry;
 
         added = true;
         is_set = true;


### PR DESCRIPTION
* Changed supertype from `Sprite` to `Visual`
* Set `geometry` (from `Visual`) to the strongly typed `_geometry` to use functions from supertypes to manipulate `geometry` and `_geometry`
* Remove (now) redundant overriding functions