### PR TITLE
Copy from 'rect' options

### DIFF
--- a/phoenix/geometry/QuadGeometry.hx
+++ b/phoenix/geometry/QuadGeometry.hx
@@ -27,6 +27,13 @@ class QuadGeometry extends Geometry {
         if(options.flipx != null) flipx = options.flipx;
         if(options.flipy != null) flipy = options.flipy;
 
+        if(options.rect != null) {
+            options.x = options.rect.x;
+            options.y = options.rect.y;
+            options.w = options.rect.w;
+            options.h = options.rect.h;
+        }
+
             //Init
         _uv_cache = new luxe.Rectangle(0,0,1,1);
 


### PR DESCRIPTION
Added missing overrides from rect options parameter - it was not being
taken into account at all. Now consistent with
http://luxeengine.com/docs/api/luxe/options/DrawBoxOptions.html