### PR TITLE
Add named binding for Gamepad Buttons

### DIFF
--- a/luxe/Core.hx
+++ b/luxe/Core.hx
@@ -769,7 +769,7 @@ class Core extends snow.App {
         }
 
         if(!shutting_down) {
-
+            input.check_named_gamepad_keys( event, true);
             emitter.emit(Ev.gamepaddown,event);
             game.ongamepaddown(event);
 
@@ -790,7 +790,7 @@ class Core extends snow.App {
         }
 
         if(!shutting_down) {
-
+            input.check_named_gamepad_keys( event, false);
             emitter.emit(Ev.gamepadup, event);
             game.ongamepadup(event);
 

--- a/luxe/Core.hx
+++ b/luxe/Core.hx
@@ -769,7 +769,7 @@ class Core extends snow.App {
         }
 
         if(!shutting_down) {
-            input.check_named_gamepad_keys( event, true);
+            input.check_named_gamepad_buttons( event, true);
             emitter.emit(Ev.gamepaddown,event);
             game.ongamepaddown(event);
 
@@ -790,7 +790,7 @@ class Core extends snow.App {
         }
 
         if(!shutting_down) {
-            input.check_named_gamepad_keys( event, false);
+            input.check_named_gamepad_buttons( event, false);
             emitter.emit(Ev.gamepadup, event);
             game.ongamepadup(event);
 

--- a/luxe/Input.hx
+++ b/luxe/Input.hx
@@ -225,9 +225,11 @@ class Input {
 #if neko
     var key_bindings : Map<String, haxe.ds.EnumValueMap<Int,Bool> >;
     var mouse_bindings : Map<String, haxe.ds.EnumValueMap<Int,Bool> >;
+    var gamepad_bindings : Map<String, haxe.ds.EnumValueMap<Int,Int> >;
 #else
     var key_bindings : Map<String, Map<Int,Bool> >;
     var mouse_bindings : Map<String, Map<Int,Bool> >;
+    var gamepad_bindings: Map<String, Map<Int, Int> >;
 #end
 
     var _named_input_released : Map<String, Bool>;
@@ -238,6 +240,7 @@ class Input {
 
         key_bindings = new Map();
         mouse_bindings = new Map();
+        gamepad_bindings = new Map();
 
         _named_input_down = new Map();
         _named_input_pressed = new Map();
@@ -397,6 +400,16 @@ class Input {
 
     } //bind_mouse
 
+    /** Bind a named input binding to a `Gamepad Key` */
+    public function bind_gamepad( _name:String, _gamepad_key:Int, _gamepad_id:Int = -1) {
+        if ( !gamepad_bindings.exists(_name) ) {
+            gamepad_bindings.set(_name, new Map<Int, Int>() );
+        }
+
+        var gp = gamepad_bindings.get(_name);
+        gp.set ( _gamepad_key, _gamepad_id);
+    } //bind_gamepad
+
     @:noCompletion public function check_named_keys( e:KeyEvent, _down:Bool=false ) {
 
         var _fired : Array<String> = [];
@@ -492,5 +505,53 @@ class Input {
         } //_f in _fired
 
     } //check_named_keys
+
+    @:noCompletion public function check_named_gamepad_keys( e:GamepadEvent, _down:Bool=false) {
+
+        var _fired : Array<String> = [];
+        for (_name in gamepad_bindings.keys()) {
+
+            var _b = gamepad_bindings.get(_name);
+            if (_b.exists(e.button)) {
+                var _kb = _b.get(e.button);
+                var _accepted_gamepad = _kb == -1 || e.gamepad == _kb;
+                if ( !Lambda.has(_fired, _name) && _accepted_gamepad) {
+                    _fired.push(_name);
+                }
+            } // if the key fired is stored in a named binding
+        }
+
+        for(_f in _fired) {
+            if (_down) {
+
+                //down but now yet processed
+                _named_input_pressed.set( _f, false);
+                // down is true immediate, because up removes it
+                _named_input_down.set( _f, true);
+
+                core.oninputdown( _f, {
+                    name: _f,
+                    type: InputType.mouse,
+                    state: InteractState.down,
+                    gamepad_event: e
+                });
+
+            } else {
+
+                // up but not yet processed
+                _named_input_released.set( _f, false);
+                // remove down state
+                _named_input_down.remove( _f );
+
+                core.oninputup( _f, {
+                    name: _f,
+                    type: InputType.mouse,
+                    state: InteractState.up,
+                    gamepad_event: e
+                });
+
+            }
+        } //_f in _fired
+    } //check_named_gamepad_keys
 
 } //Input

--- a/luxe/Input.hx
+++ b/luxe/Input.hx
@@ -225,11 +225,11 @@ class Input {
 #if neko
     var key_bindings : Map<String, haxe.ds.EnumValueMap<Int,Bool> >;
     var mouse_bindings : Map<String, haxe.ds.EnumValueMap<Int,Bool> >;
-    var gamepad_bindings : Map<String, haxe.ds.EnumValueMap<Int,Int> >;
+    var gamepad_bindings : Map<String, haxe.ds.EnumValueMap<Int, Null<Int>> >;
 #else
     var key_bindings : Map<String, Map<Int,Bool> >;
     var mouse_bindings : Map<String, Map<Int,Bool> >;
-    var gamepad_bindings: Map<String, Map<Int, Int> >;
+    var gamepad_bindings: Map<String, Map<Int, Null<Int>> >;
 #end
 
     var _named_input_released : Map<String, Bool>;
@@ -400,14 +400,14 @@ class Input {
 
     } //bind_mouse
 
-    /** Bind a named input binding to a `Gamepad Key` */
-    public function bind_gamepad( _name:String, _gamepad_key:Int, _gamepad_id:Int = -1) {
+    /** Bind a named input binding to a `Gamepad Button`. If no `Gamepad Id` is specified, any gamepad fires the named binding.*/
+    public function bind_gamepad( _name:String, _gamepad_button:Int, ?_gamepad_id:Null<Int> = null) {
         if ( !gamepad_bindings.exists(_name) ) {
-            gamepad_bindings.set(_name, new Map<Int, Int>() );
+            gamepad_bindings.set(_name, new Map<Int, Null<Int>>());
         }
 
         var gp = gamepad_bindings.get(_name);
-        gp.set ( _gamepad_key, _gamepad_id);
+        gp.set ( _gamepad_button, _gamepad_id);
     } //bind_gamepad
 
     @:noCompletion public function check_named_keys( e:KeyEvent, _down:Bool=false ) {
@@ -506,7 +506,7 @@ class Input {
 
     } //check_named_keys
 
-    @:noCompletion public function check_named_gamepad_keys( e:GamepadEvent, _down:Bool=false) {
+    @:noCompletion public function check_named_gamepad_buttons( e:GamepadEvent, _down:Bool=false) {
 
         var _fired : Array<String> = [];
         for (_name in gamepad_bindings.keys()) {
@@ -514,7 +514,7 @@ class Input {
             var _b = gamepad_bindings.get(_name);
             if (_b.exists(e.button)) {
                 var _kb = _b.get(e.button);
-                var _accepted_gamepad = _kb == -1 || e.gamepad == _kb;
+                var _accepted_gamepad = _kb == null || _kb == e.gamepad;
                 if ( !Lambda.has(_fired, _name) && _accepted_gamepad) {
                     _fired.push(_name);
                 }
@@ -531,7 +531,7 @@ class Input {
 
                 core.oninputdown( _f, {
                     name: _f,
-                    type: InputType.mouse,
+                    type: InputType.gamepad,
                     state: InteractState.down,
                     gamepad_event: e
                 });
@@ -545,13 +545,13 @@ class Input {
 
                 core.oninputup( _f, {
                     name: _f,
-                    type: InputType.mouse,
+                    type: InputType.gamepad,
                     state: InteractState.up,
                     gamepad_event: e
                 });
 
             }
         } //_f in _fired
-    } //check_named_gamepad_keys
+    } //check_named_gamepad_buttons
 
 } //Input

--- a/tests/features/input_bindings/src/Main.hx
+++ b/tests/features/input_bindings/src/Main.hx
@@ -1,8 +1,6 @@
 
 import luxe.Vector;
 import luxe.Input;
-import snow.input.gamepad.XBox360Buttons;
-import snow.input.gamepad.PS3Buttons;
 
 class Main extends luxe.Game {
 
@@ -15,10 +13,12 @@ class Main extends luxe.Game {
         Luxe.input.bind_key('fire', Key.space);
         Luxe.input.bind_key('fire', Key.key_z);
         Luxe.input.bind_mouse('fire', MouseButton.left);
-        Luxe.input.bind_gamepad('fire', XBox360Buttons.button_b);
 
-        //needs two gamepads connected for this to work
-        Luxe.input.bind_gamepad('jump', PS3Buttons.cross, 1);
+        // all gamepads fires this named binding when button 0 is pressed
+        Luxe.input.bind_gamepad('fire', 0);
+
+        //only the gamepad=1 fires this named binding when button 2 is pressed
+        Luxe.input.bind_gamepad('jump', 2, 1);
 
     } //ready
 

--- a/tests/features/input_bindings/src/Main.hx
+++ b/tests/features/input_bindings/src/Main.hx
@@ -1,6 +1,8 @@
 
 import luxe.Vector;
 import luxe.Input;
+import snow.input.gamepad.XBox360Buttons;
+import snow.input.gamepad.PS3Buttons;
 
 class Main extends luxe.Game {
 
@@ -13,6 +15,10 @@ class Main extends luxe.Game {
         Luxe.input.bind_key('fire', Key.space);
         Luxe.input.bind_key('fire', Key.key_z);
         Luxe.input.bind_mouse('fire', MouseButton.left);
+        Luxe.input.bind_gamepad('fire', XBox360Buttons.button_b);
+
+        //needs two gamepads connected for this to work
+        Luxe.input.bind_gamepad('jump', PS3Buttons.cross, 1);
 
     } //ready
 
@@ -22,6 +28,7 @@ class Main extends luxe.Game {
 
     override function oninputdown( _input:String, e:InputEvent ) {
         trace( 'named input down : ' + _input );
+
     } //oninputdown
 
     override function onkeyup( e:KeyEvent ) {


### PR DESCRIPTION
Named binding for gamepad buttons following closely the existing implementation for keys and mouse buttons binding.

binding_gamepad has an extra parameter to define the gamepad id that should respond to the binded trigger
By default, all gamepads will fire the binding