### PR TITLE
fix for rotation squishing

### DIFF
--- a/phoenix/Transform.hx
+++ b/phoenix/Transform.hx
@@ -218,10 +218,10 @@ class Transform extends ID {
                 //translate to origin
         local.matrix.makeTranslation( origin.x, origin.y, origin.z );
 
-                //scale up relative to origin
-            local.matrix.scale(local.scale);
                 //rotation relative to origin
             local.matrix.multiply(_rotation_matrix);
+                //scale up relative to origin
+            local.matrix.scale(local.scale);
                 //apply position
             local.matrix.setPosition( local.pos );
 


### PR DESCRIPTION
changes the order of the matrix operations so that rotation precedes
scaling; this fixes “squishy” looking rotations of scaled objects