### PR TITLE
Error on TiledLayer.hx getInt32

### DIFF
--- a/luxe/importers/tiled/TiledLayer.hx
+++ b/luxe/importers/tiled/TiledLayer.hx
@@ -219,7 +219,7 @@ class TiledLayer {
         byte_pos = 0;
 
         while(byte_pos < byte_len) {
-            result.push( bytes.getInt32(byte_pos) );
+            result.push( bytes.get(byte_pos) );
             byte_pos += 4; //int32 is 4 bytes
         }
 


### PR DESCRIPTION
Tiles test fails with haxe 3.1.3 and Bytes.getInt32. Since haxe docs don't show that function, I suppose it's right this way.