### PR TITLE
new fix for getInt32 replacement to work with haxe 3.1.3 

### DIFF
--- a/luxe/importers/tiled/TiledLayer.hx
+++ b/luxe/importers/tiled/TiledLayer.hx
@@ -219,7 +219,7 @@ class TiledLayer {
         byte_pos = 0;
 
         while(byte_pos < byte_len) {
-            result.push( bytes.getInt32(byte_pos) );
+            result.push( bytes.get(byte_pos) );
             byte_pos += 4; //int32 is 4 bytes
         }
 

--- a/luxe/importers/tiled/TiledLayer.hx
+++ b/luxe/importers/tiled/TiledLayer.hx
@@ -219,7 +219,13 @@ class TiledLayer {
         byte_pos = 0;
 
         while(byte_pos < byte_len) {
-            result.push( bytes.get(byte_pos) );
+            var tmp = bytes.get(byte_pos + 0);
+        	var ret = 0;
+        	ret |= (bytes.get(byte_pos + 0) << 8 * 0);
+        	ret |= (bytes.get(byte_pos + 1) << 8 * 1);
+        	ret |= (bytes.get(byte_pos + 2) << 8 * 2);
+        	ret |= (bytes.get(byte_pos + 3) << 8 * 3);
+            result.push( ret );
             byte_pos += 4; //int32 is 4 bytes
         }
 


### PR DESCRIPTION
I **think** this is the way. At least, tried to export a TiledMap to .tmx with map encoded in base64 and it works. The only still possible creepy thing is endianness since it's not controlled.