### PR TITLE
Ray/shape collision fix

### DIFF
--- a/luxe/collision/ShapeDrawerLuxe.hx
+++ b/luxe/collision/ShapeDrawerLuxe.hx
@@ -28,6 +28,11 @@ class ShapeDrawerLuxe extends ShapeDrawer {
 
         assertnull(circle);
 
+        var smoothVal = 10.0;
+        if (circle.transformedRadius < 2.0 ) {
+            smoothVal = 20.0;
+        }
+
         Luxe.draw.ring({
             x: circle.position.x,
             y: circle.position.y,
@@ -36,7 +41,8 @@ class ShapeDrawerLuxe extends ShapeDrawer {
             depth: options.depth,
             group: options.group,
             immediate: options.immediate,
-            batcher: options.batcher
+            batcher: options.batcher,
+            smooth: smoothVal
         });
 
     }

--- a/luxe/collision/sat/SAT2D.hx
+++ b/luxe/collision/sat/SAT2D.hx
@@ -239,7 +239,7 @@ class SAT2D {
             var t1:Float = (-b - d) / (2 * a);
             var t2:Float = (-b + d) / (2 * a);
 
-            if (ray.infinite || t1 <= 1.0) {
+            if (ray.infinite || ((t1 <= 1.0)&&(t1 >=0.0)) ) {
                 return new RayCollision(circle, ray, t1, t2);
             }
 
@@ -284,7 +284,7 @@ class SAT2D {
 
             } //each vert
 
-            if(ray.infinite || min_u <= 1.0) {
+            if(ray.infinite || ((min_u <= 1.0) && (min_u >= 0.0)) ) {
                 return new RayCollision(polygon, ray, min_u, max_u);
             }
 

--- a/tests/features/collision/src/states/RayAndShape.hx
+++ b/tests/features/collision/src/states/RayAndShape.hx
@@ -24,10 +24,13 @@ class RayAndShape extends luxe.States.State {
 
         Main.display('pink = ray\ngreen = before hit\nwhite = intersection\npurple = after hit');
 
-        beam = new Ray( new Vector(10,300), new Vector(400,100), false );
+        beam = new Ray( new Vector(450,300), new Vector(400,100), false );
 
         Main.rays.push(beam);
-        Main.shapes.push(new Circle(300,300,50));
+        Main.shapes.push(new Circle(600,400,50));
+        Main.shapes.push(new Circle(200,400,50));
+        Main.shapes.push( Polygon.rectangle(600,200,50,50));
+        Main.shapes.push( Polygon.rectangle(200,200,50,50));
 
         intersect = Luxe.draw.line({ depth:100, group:3, p0:new Vector(), p1:new Vector(), color:new Color().rgb(0xffffff) });
         before = Luxe.draw.line({ depth:100, group:2, p0:new Vector(), p1:new Vector(), color:new Color().rgb(0x00f67b) });
@@ -59,31 +62,43 @@ class RayAndShape extends luxe.States.State {
 
         if(Main.shapes.length <= 0) return;
 
-        var c = Collision.rayWithShape(beam, Main.shapes[0]);
+        var colls = Collision.rayWithShapes(beam, Main.shapes);
 
-        if(c != null) {
+        Luxe.draw.text({
+            point_size:15,
+            pos:new Vector(Luxe.screen.w - 10,10),
+            align: right,
+            text: 'Hit ${colls.length} shapes',
+            immediate:true,
+        });
 
-            var hitstart = c.hitStart();
-            var hitend = c.hitEnd();
-            var raystart = c.ray.start;
-            var rayend = c.ray.end;
+        var textYval = 30;
+        if(colls.length > 0) {
 
-            intersect.p0 = hitstart;
-            intersect.p1 = hitend;
+            for (c in colls) {
+                var hitstart = c.hitStart();
+                var hitend = c.hitEnd();
+                var raystart = c.ray.start;
+                var rayend = c.ray.end;
 
-            before.p0 = raystart;
-            before.p1 = hitstart;
+                intersect.p0 = hitstart;
+                intersect.p1 = hitend;
 
-            after.p0 = hitend;
-            after.p1 = rayend;
+                before.p0 = raystart;
+                before.p1 = hitstart;
 
-            Luxe.draw.text({
-                point_size:13,
-                pos:new Vector(Luxe.screen.w - 10,10),
-                align: right,
-                text: 'hit start %: ${c.start}\n end %: ${c.end}',
-                immediate:true,
-            });
+                after.p0 = hitend;
+                after.p1 = rayend;
+
+                Luxe.draw.text({
+                    point_size:13,
+                    pos:new Vector(Luxe.screen.w - 10,textYval),
+                    align: right,
+                    text: 'hit start %: ${c.start}\n end %: ${c.end}',
+                    immediate:true,
+                });
+                textYval += 30;
+            }
 
         }
 


### PR DESCRIPTION
Fix for a bug I encountered during my ludumdare 32 entry. 

This fixes rays falsely reporting collisions with objects behind them. Didn't show up in the collision test example because shapes were always in front of the rays. I also modified the collision test to verify this bug, and to also test ray/polygon in addition to ray/circle.

Note I think this might be in incomplete fix, this bug might still happen with "infinite=true" rays, but this fixes it enough for my project.