### PR TITLE
Collision; remove unnessesary Vector allocations in ShapeCollision.hx

### DIFF
--- a/luxe/collision/data/ShapeCollision.hx
+++ b/luxe/collision/data/ShapeCollision.hx
@@ -21,10 +21,6 @@ class ShapeCollision {
 
     @:noCompletion
     public function new() {
-
-        separation = new Vector();
-        unitVector = new Vector();
-
     } //new
 
 } //ShapeCollision


### PR DESCRIPTION
Saves 2 unnecessary Vector allocations for every collision, could also be left in and instead have the SAT2D class use set_xy on them, but this was faster for me to create the pull as some of the test_() functions use temp vectors and such.

I know there are many optimizations that could be done on the Collision classes (the amount of vectors created is staggering) and that optimization is not your priority currently, but this is a pretty innocent way to save a sizeable amount of allocations with a very tiny change (that does not affect API)

Nico