### PR TITLE
Entity; fix typo, prevent infinite loop when looking for root entity

### DIFF
--- a/luxe/Entity.hx
+++ b/luxe/Entity.hx
@@ -501,7 +501,7 @@ class Entity extends Objects {
                     } else {
                         //still has a parent,
                         //keep looking
-                        _parent = parent.parent;
+                        _parent = _parent.parent;
                     }
 
                 } else {


### PR DESCRIPTION
Fixes a typo that made the recursive loop infinite on some cases.