### PR TITLE
Entity.active_path

### DIFF
--- a/luxe/Entity.hx
+++ b/luxe/Entity.hx
@@ -43,6 +43,8 @@ class Entity extends Objects {
     @:isVar public var scene            (get,set) : Scene;
         /** if the entity is active in the scene or not. set to inactive to stop scene events propogating into this entity and it's components and children */
     @:isVar public var active           (get,set) : Bool = true;
+        /** if the entity is active, as well as all of its parents. */
+    @:isVar public var active_path   (get,null) : Bool = true;
 
         /** The spatial transform of the entity. */
     @:isVar public var transform        (get,set) : Transform;
@@ -1202,6 +1204,8 @@ class Entity extends Objects {
         } else {
             transform.parent = null;
         }
+        
+        update_active_path();
 
         return parent;
 
@@ -1254,7 +1258,11 @@ class Entity extends Objects {
 
     function set_active(_active:Bool) : Bool {
 
-        return active = _active;
+        active = _active;
+
+        update_active_path();
+
+        return active;
 
     } //set_active
 
@@ -1263,6 +1271,23 @@ class Entity extends Objects {
         return active;
 
     } //get_active
+
+//active_path
+
+    function update_active_path() {
+        active_path = active && (parent == null || parent.active_path);
+	
+    	for (c in this.children)
+    	{
+    		c.update_active_path();
+    	}
+    }
+
+    function get_active_path() {
+
+        return active_path;
+
+    } //get_active_path
 
 // 
 

--- a/luxe/Events.hx
+++ b/luxe/Events.hx
@@ -82,11 +82,11 @@ class Events {
         /** Bind a signal (listener) to a slot (event_name)
             event_name : The event id
             listener : A function handler that should get called on event firing */
-    public function listen<T>( _event_name : String, _listener : T -> Void ):String {
+    public function listen<T>( _event_name : String, _listener : T -> Void, _entity:Entity = null ):String {
 
             //we need an ID and a connection to store
         var _id = Luxe.utils.uniqueid();
-        var _connection = new EventConnection( _id, _event_name, _listener );
+        var _connection = new EventConnection( _id, _event_name, _listener, _entity );
 
             //now we store it in the map
         event_connections.set( _id, _connection );
@@ -226,7 +226,9 @@ class Events {
                     }
 
                     for(_connection in _filter) {
-                        _connection.listener( cast _properties );
+                        if (_connection.entity == null || _connection.entity.active_path) {
+                            _connection.listener( cast _properties );
+                        }
                     } //each connection to this filter
 
                     _fired = true;
@@ -247,7 +249,9 @@ class Events {
 
                 //call each listener
             for(connection in _connections) {
-                connection.listener( cast _properties );
+                if (connection.entity == null || connection.entity.active_path) {
+                    connection.listener( cast _properties );
+                }
             }
 
             _fired = true;
@@ -317,14 +321,16 @@ private class EventConnection {
     public var listener : Dynamic -> Void;
     public var id : String;
     public var event_name : String;
+    public var entity : Entity;
 
 
-    public function new( _id:String, _event_name:String, _listener : Dynamic -> Void ) {
+    public function new( _id:String, _event_name:String, _listener : Dynamic -> Void, _entity:Entity = null ) {
 
         id = _id;
         listener = _listener;
         event_name = _event_name;
-
+        entity = _entity;
+        
     } //new
 
 

--- a/luxe/Visual.hx
+++ b/luxe/Visual.hx
@@ -21,6 +21,7 @@ import luxe.Log.*;
 
 class Visual extends Entity {
 
+    public static var _ACTIVE_BASED_VISIBILITY:Bool = true;
 
         /** the size of this geometry (only makes sense for QuadGeometry) */
     @:isVar public var size         (default,set) : Vector;
@@ -156,6 +157,8 @@ class Visual extends Entity {
                     //call the geometry create listener
                 on_geometry_created();
 
+                update_active_path();
+
             } //no_geometry is not present
 
         } else {
@@ -212,14 +215,22 @@ class Visual extends Entity {
 
 //Visibility properties
 
+    override function update_active_path() {
+        super.update_active_path();
+        update_geometry_visibility();
+    }
+    
+    function update_geometry_visibility() {
+        if(geometry != null) {
+            geometry.visible = visible && (!_ACTIVE_BASED_VISIBILITY || active_path);
+        }
+    }
+
     function set_visible(_v:Bool) {
 
         visible = _v;
 
-            //careful
-        if(geometry != null) {
-            geometry.visible = visible;
-        }
+        update_geometry_visibility();
 
         return visible;
 
@@ -301,7 +312,7 @@ class Visual extends Entity {
 
                         geometry.color = color;
                         geometry.depth = depth;
-                        geometry.visible = visible;
+                        update_geometry_visibility();
                         // geometry.shader = shader;
 
                         if(!ignore_texture_on_geometry_change) {


### PR DESCRIPTION
Easily hide/disable a complex nested structure of Visuals/Entities by just setting its root entity to **active = true/false**;

**Entity** has a new property **.active_path** that checks if the Entity and all of its parents have **.active==true** (think of Unity's **.activeInHierarchy**). Only updated when hierarchy changes.

Entity only receives **events** when active_path == true, Visuals are only **visible** when active_path == true (may be disabled via Visual._ACTIVE_BASED_VISIBILITY = false).

