### PR TITLE
Haxe 3.3; Workaround for 3.3.0-rc1 bug with inline constructors

### DIFF
--- a/luxe/structural/BalancedBST.hx
+++ b/luxe/structural/BalancedBST.hx
@@ -674,9 +674,9 @@ class BalancedBST<K,T> {
 #if !display @:generic #end
 class BalancedBSTIterator<K,T> {
 
-    var tree : BalancedBST<K,T>;
-    var current : BalancedBSTNode<K,T>;
-    var rightest : BalancedBSTNode<K,T>;
+    var tree : BalancedBST<K,T> = null;
+    var current : BalancedBSTNode<K,T> = null;
+    var rightest : BalancedBSTNode<K,T> = null;
 
     public inline function new(_tree:BalancedBST<K,T>) {
 

--- a/phoenix/Vector.hx
+++ b/phoenix/Vector.hx
@@ -5,10 +5,10 @@ import luxe.Log.*;
 
 class Vector {
 
-    @:isVar public var x (default, set) : Float = 0;
-    @:isVar public var y (default, set) : Float = 0;
-    @:isVar public var z (default, set) : Float = 0;
-    @:isVar public var w (default, default) : Float = 0;
+    @:isVar public var x (default, set) : Float = 0.0;
+    @:isVar public var y (default, set) : Float = 0.0;
+    @:isVar public var z (default, set) : Float = 0.0;
+    @:isVar public var w (default, default) : Float = 0.0;
 
     @:isVar public var length        (get, set) : Float;
     @:isVar public var lengthsq      (get, null) : Float;


### PR DESCRIPTION
Haxe 3.3.0-rc1 has a bug - when inline constructors are used on values returned from inline functions and not stored in a local variables, they will be typed with their initializer and not the actual declaration type.

If class has field declared as `var x : Float = 0;` temporary variable will have type Int as it's type of variable initializer.

Related haxe issue https://github.com/HaxeFoundation/haxe/issues/5340

In case of `BalancedBSTIterator` it seems to be related issue, but it causes compilation failure. There might be other cases, which didn't reveal themselves in my code.
