### PR TITLE
tests/features/timescale; oninputdown correction

### DIFF
--- a/tests/features/timescale/src/Main.hx
+++ b/tests/features/timescale/src/Main.hx
@@ -63,9 +63,9 @@ class Main extends luxe.Game {
 
     } //ready
 
-    override function oninputdown( name:String, e:InputEvent ) {
+    override function oninputdown( e:InputEvent ) {
 
-        if(name == 'jump') {
+        if(e.name == 'jump') {
             jump();
         } //jump pressed
 


### PR DESCRIPTION
Noticed this in the timescale test project. Not sure if the old notation is used in others. The actual error message is:

```
src/Main.hx:66: lines 66-72 : Field oninputdown overloads parent class with different or incomplete type
src/Main.hx:66: lines 66-72 : Different number of function arguments
```