### PR TITLE
phoenix; Matrix; fix element indices in get/set `m` values

### DIFF
--- a/phoenix/Matrix.hx
+++ b/phoenix/Matrix.hx
@@ -102,43 +102,43 @@ class Matrix {
     }
 
     inline function get_M11() : Float { return elements[0]; }
-    inline function get_M12() : Float { return elements[1]; }
-    inline function get_M13() : Float { return elements[2]; }
-    inline function get_M14() : Float { return elements[3]; }
+    inline function get_M12() : Float { return elements[4]; }
+    inline function get_M13() : Float { return elements[8]; }
+    inline function get_M14() : Float { return elements[12]; }
 
-    inline function get_M21() : Float { return elements[4]; }
+    inline function get_M21() : Float { return elements[1]; }
     inline function get_M22() : Float { return elements[5]; }
-    inline function get_M23() : Float { return elements[6]; }
-    inline function get_M24() : Float { return elements[7]; }
+    inline function get_M23() : Float { return elements[9]; }
+    inline function get_M24() : Float { return elements[13]; }
 
-    inline function get_M31() : Float { return elements[8]; }
-    inline function get_M32() : Float { return elements[9]; }
+    inline function get_M31() : Float { return elements[2]; }
+    inline function get_M32() : Float { return elements[6]; }
     inline function get_M33() : Float { return elements[10]; }
-    inline function get_M34() : Float { return elements[11]; }
+    inline function get_M34() : Float { return elements[14]; }
 
-    inline function get_M41() : Float { return elements[12]; }
-    inline function get_M42() : Float { return elements[13]; }
-    inline function get_M43() : Float { return elements[14]; }
+    inline function get_M41() : Float { return elements[3]; }
+    inline function get_M42() : Float { return elements[7]; }
+    inline function get_M43() : Float { return elements[11]; }
     inline function get_M44() : Float { return elements[15]; }
 
     inline function set_M11( _value:Float ) : Float { elements[0] = _value; return _value; }
-    inline function set_M12( _value:Float ) : Float { elements[1] = _value; return _value; }
-    inline function set_M13( _value:Float ) : Float { elements[2] = _value; return _value; }
-    inline function set_M14( _value:Float ) : Float { elements[3] = _value; return _value; }
+    inline function set_M12( _value:Float ) : Float { elements[4] = _value; return _value; }
+    inline function set_M13( _value:Float ) : Float { elements[8] = _value; return _value; }
+    inline function set_M14( _value:Float ) : Float { elements[12] = _value; return _value; }
 
-    inline function set_M21( _value:Float ) : Float { elements[4] = _value; return _value; }
+    inline function set_M21( _value:Float ) : Float { elements[1] = _value; return _value; }
     inline function set_M22( _value:Float ) : Float { elements[5] = _value; return _value; }
-    inline function set_M23( _value:Float ) : Float { elements[6] = _value; return _value; }
-    inline function set_M24( _value:Float ) : Float { elements[7] = _value; return _value; }
+    inline function set_M23( _value:Float ) : Float { elements[9] = _value; return _value; }
+    inline function set_M24( _value:Float ) : Float { elements[13] = _value; return _value; }
 
-    inline function set_M31( _value:Float ) : Float { elements[8] = _value; return _value; }
-    inline function set_M32( _value:Float ) : Float { elements[9] = _value; return _value; }
+    inline function set_M31( _value:Float ) : Float { elements[2] = _value; return _value; }
+    inline function set_M32( _value:Float ) : Float { elements[6] = _value; return _value; }
     inline function set_M33( _value:Float ) : Float { elements[10] = _value; return _value; }
-    inline function set_M34( _value:Float ) : Float { elements[11] = _value; return _value; }
+    inline function set_M34( _value:Float ) : Float { elements[14] = _value; return _value; }
 
-    inline function set_M41( _value:Float ) : Float { elements[12] = _value; return _value; }
-    inline function set_M42( _value:Float ) : Float { elements[13] = _value; return _value; }
-    inline function set_M43( _value:Float ) : Float { elements[14] = _value; return _value; }
+    inline function set_M41( _value:Float ) : Float { elements[3] = _value; return _value; }
+    inline function set_M42( _value:Float ) : Float { elements[7] = _value; return _value; }
+    inline function set_M43( _value:Float ) : Float { elements[11] = _value; return _value; }
     inline function set_M44( _value:Float ) : Float { elements[15] = _value; return _value; }
 
     public inline function float32array() : snow.api.buffers.Float32Array {


### PR DESCRIPTION
Right now the indices for the individual matrix element getters and setters are in reverse order from the constructor, set, and tostring