### PR TITLE
Fixed RingGeometry to accept angles from 0 to 360 (less than one full turn).

### DIFF
--- a/phoenix/geometry/RingGeometry.hx
+++ b/phoenix/geometry/RingGeometry.hx
@@ -57,8 +57,8 @@ class RingGeometry extends Geometry {
             //adapted from
             //http://slabode.exofire.net/circle_draw.shtml
 
-            var _start_angle_rad = luxe.utils.Maths.radians(_start_angle_degrees);
-            var _end_angle_rad = luxe.utils.Maths.radians(_end_angle_degrees);
+            var _start_angle_rad = luxe.utils.Maths.radians(_start_angle_degrees % 360);
+            var _end_angle_rad = luxe.utils.Maths.radians(_end_angle_degrees % 360);
 
             var _range = _end_angle_rad - _start_angle_rad;
 


### PR DESCRIPTION
To replicate this bug, call Luxe.draw.arc() with start_angle 0 and end_angle > 360. It will draw the same number of segments for more than one turn, so it will cause visual errors.