### PR TITLE
Add cloned shader to luxe resources and Fix Tiled Image Layer position

### DIFF
--- a/luxe/importers/tiled/TiledImageLayer.hx
+++ b/luxe/importers/tiled/TiledImageLayer.hx
@@ -33,8 +33,8 @@ class TiledImageLayer {
     public function from_xml( xml:Xml ) {
 
         name = xml.get("name");
-        x = Std.parseInt(xml.get("x"));
-        y = Std.parseInt(xml.get("y"));
+        x = Std.parseInt(xml.get("offsetx"));
+        y = Std.parseInt(xml.get("offsety"));
 
         var _opacity = xml.get("opacity");
         var _visible = xml.get("visible");
@@ -72,8 +72,8 @@ class TiledImageLayer {
     public function from_json( json:Dynamic ) {
 
         name = Reflect.field(json, "name");
-        x = cast Reflect.field(json, "x");
-        y = cast Reflect.field(json, "y");
+        x = cast Reflect.field(json, "offsetx");
+        y = cast Reflect.field(json, "offsety");
         opacity = Reflect.field(json, "opacity");
         visible = Reflect.field(json, "visible");
 

--- a/phoenix/Shader.hx
+++ b/phoenix/Shader.hx
@@ -430,6 +430,8 @@ class Shader extends Resource {
 
         _clone.from_string( vert_source, frag_source );
 
+        Luxe.resources.add(_clone);
+
         return _clone;
 
     } //clone


### PR DESCRIPTION
- Add a cloned shader to the luxe resources so it can be destroyed later
- The current tiled version uses offsetx and offsety to store the position of an
image